### PR TITLE
Use UTC time for BSON value_transform

### DIFF
--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -178,7 +178,7 @@ module MoSQL
       case value
       when BSON::Binary, BSON::ObjectId
         if [:DATE, :TIMESTAMP, :TIME].include? type.to_sym
-          Time.at value.to_s[0...8].to_i(16)
+          Time.at(value.to_s[0...8].to_i(16)).utc
         else
           value.to_s
         end


### PR DESCRIPTION
The schema creates `timestamp without timezone` fields, which will discard any 
timezone information present in the `to_s` output of the timezone object. This ensures
that the proper time is stored in postgresql.

E.G. (where "5555f7e2" is the first 8 characters of a mongodb ObjectId, representing 
the time at which it was created):

`ruby -e 'puts(Time.at "5555f7e2".to_i(16))'`
2015-05-15 09:42:58 -0400

`ruby -e 'puts((Time.at "5555f7e2".to_i(16)).utc)'`
2015-05-15 13:42:58 UTC